### PR TITLE
getPopCounts bug

### DIFF
--- a/src/R_API.cpp
+++ b/src/R_API.cpp
@@ -39,12 +39,13 @@ Rcpp::List getPopCounts(Rcpp::XPtr<GatingSet> gsPtr, StringVec sampleNames, Stri
 	Rcpp::IntegerVector countVec(nVec);
 	Rcpp::IntegerVector parentCountVec(nVec);
 
-	StringVec allNodes = gsPtr->getGatingHierarchy(sampleNames.at(0))->getPopPaths(REGULAR, isFullPath, true);
+	// StringVec allNodes = gsPtr->getGatingHierarchy(sampleNames.at(0))->getPopPaths(REGULAR, isFullPath, true);
 
 	unsigned counter = 0;
 	for(unsigned i = 0; i < nSample; i++){
 		std::string sn = sampleNames.at(i);
 		GatingHierarchy * gh = gsPtr->getGatingHierarchy(sn);
+		StringVec allNodes = gsPtr->getGatingHierarchy(sampleNames.at(i))->getPopPaths(REGULAR, isFullPath, true);
 		for(unsigned j = 0; j < nPop; j++){
 			 	std::string pop = subpopulation.at(j);
 				sampleVec(counter) = sn;


### PR DESCRIPTION
allNodes is derived from the first sample only.
When different samples have nodes ordered differently this causes
getPopStats to return an incorrect mapping of parent to child.
Fetching allNodes for each sample specifically corrects this.

Paul will provide a test case.
