### PR TITLE
Fix typo in markernames replacement method.

### DIFF
--- a/R/cytoframe.R
+++ b/R/cytoframe.R
@@ -441,8 +441,7 @@ setReplaceMethod("markernames",
         #validity check
 		oldmarkers <- pdata[["desc"]]		
 		oldmarkers[inds] <- value
-		oldmarkers <- oldmarkers[!is.na(oldmarkers)]
-		oldmarkers <- oldmarkers[oldmarkers != ""]
+		oldmarkers <- oldmarkers[!is.na(oldmarkers) & oldmarkers != ""]
 		dup <- duplicated(oldmarkers)
 		if(any(dup))
 		{

--- a/R/cytoframe.R
+++ b/R/cytoframe.R
@@ -442,8 +442,8 @@ setReplaceMethod("markernames",
 		oldmarkers <- pdata[["desc"]]		
 		oldmarkers[inds] <- value
 		oldmarkers <- oldmarkers[!is.na(oldmarkers)]
+		oldmarkers <- oldmarkers[oldmarkers != ""]
 		dup <- duplicated(oldmarkers)
-		dup <- dup[!dup == ""]
 		if(any(dup))
 		{
 			

--- a/R/cytoframe.R
+++ b/R/cytoframe.R
@@ -443,6 +443,7 @@ setReplaceMethod("markernames",
 		oldmarkers[inds] <- value
 		oldmarkers <- oldmarkers[!is.na(oldmarkers)]
 		dup <- duplicated(oldmarkers)
+		dup <- dup[!dup == ""]
 		if(any(dup))
 		{
 			

--- a/R/cytoframe.R
+++ b/R/cytoframe.R
@@ -446,7 +446,7 @@ setReplaceMethod("markernames",
 		if(any(dup))
 		{
 			
-			stop("Trying to assing the marker: ", oldmarkers[dup][1], " to multiple channels")
+			stop("Trying to assign the marker: ", oldmarkers[dup][1], " to multiple channels")
 		}
 			
         for(i in seq_along(inds)){


### PR DESCRIPTION
Minor typo fix to address [CytoExploreR Issue 53](https://github.com/DillonHammill/CytoExploreR/issues/53).