### PR TITLE
Update flowWorkspace::append_cols for updated cytolib::append_columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flowWorkspace
 Type: Package
 Title: Infrastructure for representing and interacting with gated and ungated cytometry data sets.
-Version: 4.1.7
+Version: 4.1.8
 Date: 2011-06-10
 Author: Greg Finak, Mike Jiang
 Maintainer: Greg Finak <gfinak@fhcrc.org>,Mike Jiang <wjiang2@fhcrc.org>,Jake Wagner <jpwagner@fhcrc.org>
@@ -79,7 +79,7 @@ Suggests:
     parallel,
     CytoML,
     openCyto
-LinkingTo: Rcpp, BH(>= 1.62.0-1), RProtoBufLib(>= 1.99.4), cytolib (>= 2.1.1),Rhdf5lib, RcppArmadillo, RcppParallel(>= 4.4.2-1)
+LinkingTo: Rcpp, BH(>= 1.62.0-1), RProtoBufLib(>= 1.99.4), cytolib (>= 2.1.15),Rhdf5lib, RcppArmadillo, RcppParallel(>= 4.4.2-1)
 VignetteBuilder: knitr
 biocViews: ImmunoOncology, FlowCytometry, DataImport, Preprocessing, DataRepresentation
 SystemRequirements: GNU make, C++11

--- a/src/cytoframeAPI.cpp
+++ b/src/cytoframeAPI.cpp
@@ -146,27 +146,13 @@ void setChannel(Rcpp::XPtr<CytoFrameView> fr, string old, string new_name){
 // [[Rcpp::export]]
 Rcpp::XPtr<CytoFrameView> append_cols(Rcpp::XPtr<CytoFrameView> fr, vector<string> new_colnames, NumericMatrix new_cols_mat){
   
-  CytoFrameView new_fr = fr->copy_realized();
-  CytoFramePtr ptr = new_fr.get_cytoframe_ptr();
-  string new_uri = ptr->get_uri();
-  FileFormat fmt = ptr->get_backend_type();
-  
-  // For now, push all backends through MemCytoFrame::append_columns
-  // by conversion
-  if(fmt != FileFormat::MEM)
-    ptr.reset(new MemCytoFrame(*ptr));
   
   // Add the columns to the MemCytoFrame
   arma::mat new_cols = as<arma::mat>(new_cols_mat);
-  ptr->append_columns(new_colnames, new_cols);
+  fr->append_columns(new_colnames, new_cols);
   
-  // If necessary, convert back to prior backend, overwriting the copy uri.
-  if(fmt != FileFormat::MEM){
-    ptr->write_to_disk(new_uri, fmt);
-    ptr = load_cytoframe(new_uri, false);
-  }
-  
-  return Rcpp::XPtr<CytoFrameView>(new CytoFrameView(ptr));
+  return fr;
+  // return Rcpp::XPtr<CytoFrameView>(fr);
 }
                                       
 // [[Rcpp::export]] 


### PR DESCRIPTION
This is just to accompany https://github.com/RGLab/cytolib/pull/40, which handles the `append_columns` logic for each backend at the `cytolib` level, allowing `flowWorkspace::append_cols` to be an even thinner wrapper.