### PR TITLE
Enable forced loading of disk-backed or in-memory data 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .Rproj.user
+.vscode
 
 *.o
 *.so

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - R -e 'devtools::install_github("RGLab/flowCore")'
   - R -e 'devtools::install_github("RGLab/ncdfFlow")'
   - R -e 'devtools::install_github("RGLab/flowWorkspaceData")'
-  - R -e 'devtools::install_deps(upgrade = "Always")'
+  - R -e 'devtools::install_deps(upgrade = "always")'
 
 script:
   - R CMD build . --no-build-vignettes

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -219,8 +219,8 @@ set_gatingset_id <- function(gsPtr, id) {
     invisible(.Call(`_flowWorkspace_save_gatingset`, gs, path, backend_opt, ctx))
 }
 
-.cpp_loadGatingSet <- function(path, readonly, select_samples, verbose, ctx) {
-    .Call(`_flowWorkspace_load_gatingset`, path, readonly, select_samples, verbose, ctx)
+.cpp_loadGatingSet <- function(path, readonly, select_samples, verbose, ctx, load_format) {
+    .Call(`_flowWorkspace_load_gatingset`, path, readonly, select_samples, verbose, ctx, load_format)
 }
 
 load_legacy_gs <- function(pbfile, cs) {

--- a/R/load_gs.R
+++ b/R/load_gs.R
@@ -116,38 +116,36 @@ delete_gs <- function(path, cred = NULL){
 }
 
 #' @rdname save_gs
+#' @param load_format \code{character} Determine how the cell-level data should be loaded. Either "on-disk": use disk-backed storage, don't load the data in memory. "in-memory" load the data in memory or "default" load the data as described in the GatingSet archive. 
 #' @export
 #' @aliases load_gs load_gslist
 #' @importFrom aws.s3 get_bucket_df save_object
-load_gs<-function(path, h5_readonly = NULL, backend_readonly = TRUE, select = character(), verbose = FALSE, cred = NULL){
-  if(!is.null(h5_readonly))
-  {
+load_gs <- function(path, h5_readonly = NULL, backend_readonly = TRUE, select = character(), verbose = FALSE, cred = NULL, load_format = c("default", "on-disk", "in-memory")) {
+  if (!is.null(h5_readonly)) {
     warning("'h5_readonly' is deprecated by 'backend_readonly'!")
     backend_readonly <- h5_readonly
   }
   cred <- check_credential(cred)
-  if(!is_s3_path(path))
-  {
-    
-    
-    if(length(list.files(path = path, pattern = ".rds")) >0)
-    {
+  if (!is_s3_path(path)) {
+
+
+    if (length(list.files(path = path, pattern = ".rds")) > 0) {
       stop("'", path, "' appears to be the legacy GatingSet archive folder!\nPlease use 'convert_legacy_gs()' to convert it to the new format.")
     }
-	  path <- normalizePath(path)
+    path <- normalizePath(path)
     sns <- sampleNames(path)
-    
+
   }
-  if(!is.character(select))
-  {
+  if (!is.character(select)) {
     select.sn <- sns[select]
     idx <- is.na(select.sn)
-    if(any(idx))
+    if (any(idx))
       stop("sample selection is out of boundary: ", paste0(select[idx], ","))
-  }else
-    select.sn <- select
-  new("GatingSet", pointer = .cpp_loadGatingSet(path, backend_readonly, select.sn, verbose, cred))
-  
+    } else {
+      select.sn <- select
+    }
+  load_format = match.arg(load_format, c("default", "on-disk", "in-memory"));
+  new("GatingSet", pointer = .cpp_loadGatingSet(path, backend_readonly, select.sn, verbose, cred, load_format))
 }
 
 #' Get sample names from a GatingSet archive folder

--- a/man/save_gs.Rd
+++ b/man/save_gs.Rd
@@ -23,7 +23,8 @@ load_gs(
   backend_readonly = TRUE,
   select = character(),
   verbose = FALSE,
-  cred = NULL
+  cred = NULL,
+  load_format = c("default", "on-disk", "in-memory")
 )
 
 \S4method{sampleNames}{character}(object)
@@ -51,6 +52,8 @@ when NULL, read the default credential file from disk (e.g., ~/.aws/credentials)
 \item{select}{an integer or character vector to select a subset of samples to load}
 
 \item{verbose}{logical flag to optionally print the versions of the libraries that were used to archive the GatingSet for troubleshooting purpose.}
+
+\item{load_format}{\code{character} Determine how the cell-level data should be loaded. Either "on-disk": use disk-backed storage, don't load the data in memory. "in-memory" load the data in memory or "default" load the data as described in the GatingSet archive.}
 
 \item{object}{a \code{GatingSet} folder}
 

--- a/src/R_GatingSet.cpp
+++ b/src/R_GatingSet.cpp
@@ -208,6 +208,7 @@ void set_gatingset_id(XPtr<GatingSet> gsPtr, string id) {
 /*
  * save/load GatingSet
  */
+// added is_skip_data = false to save_gatingset method
 //[[Rcpp::export(name=".cpp_saveGatingSet")]]
 void save_gatingset(XPtr<GatingSet> gs, string path, string backend_opt, CytoCtx ctx) {
       CytoFileOption cf_opt;
@@ -225,15 +226,15 @@ void save_gatingset(XPtr<GatingSet> gs, string path, string backend_opt, CytoCtx
       }
       else
         stop("invalid backend_opt option!");
-			gs->serialize_pb(path, cf_opt, ctx);
+      gs->serialize_pb(path, cf_opt, ctx);
 }
 
 //[[Rcpp::export(name=".cpp_loadGatingSet")]]
 XPtr<GatingSet> load_gatingset(string path, bool readonly, vector<string> select_samples, bool verbose
-									, CytoCtx ctx) {
+									, CytoCtx ctx, string load_format) {
 
 
-	return XPtr<GatingSet>(new GatingSet(path, false, readonly, select_samples, verbose, ctx));
+	return XPtr<GatingSet>(new GatingSet(path, false, readonly, select_samples, verbose, ctx, load_format));
 
 }
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -564,8 +564,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // load_gatingset
-XPtr<GatingSet> load_gatingset(string path, bool readonly, vector<string> select_samples, bool verbose, CytoCtx ctx);
-RcppExport SEXP _flowWorkspace_load_gatingset(SEXP pathSEXP, SEXP readonlySEXP, SEXP select_samplesSEXP, SEXP verboseSEXP, SEXP ctxSEXP) {
+XPtr<GatingSet> load_gatingset(string path, bool readonly, vector<string> select_samples, bool verbose, CytoCtx ctx, string load_format);
+RcppExport SEXP _flowWorkspace_load_gatingset(SEXP pathSEXP, SEXP readonlySEXP, SEXP select_samplesSEXP, SEXP verboseSEXP, SEXP ctxSEXP, SEXP load_formatSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -574,7 +574,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< vector<string> >::type select_samples(select_samplesSEXP);
     Rcpp::traits::input_parameter< bool >::type verbose(verboseSEXP);
     Rcpp::traits::input_parameter< CytoCtx >::type ctx(ctxSEXP);
-    rcpp_result_gen = Rcpp::wrap(load_gatingset(path, readonly, select_samples, verbose, ctx));
+    Rcpp::traits::input_parameter< string >::type load_format(load_formatSEXP);
+    rcpp_result_gen = Rcpp::wrap(load_gatingset(path, readonly, select_samples, verbose, ctx, load_format));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1321,7 +1322,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_flowWorkspace_get_gatingset_id", (DL_FUNC) &_flowWorkspace_get_gatingset_id, 1},
     {"_flowWorkspace_set_gatingset_id", (DL_FUNC) &_flowWorkspace_set_gatingset_id, 2},
     {"_flowWorkspace_save_gatingset", (DL_FUNC) &_flowWorkspace_save_gatingset, 4},
-    {"_flowWorkspace_load_gatingset", (DL_FUNC) &_flowWorkspace_load_gatingset, 5},
+    {"_flowWorkspace_load_gatingset", (DL_FUNC) &_flowWorkspace_load_gatingset, 6},
     {"_flowWorkspace_load_legacy_gs", (DL_FUNC) &_flowWorkspace_load_legacy_gs, 2},
     {"_flowWorkspace_CloneGatingSet", (DL_FUNC) &_flowWorkspace_CloneGatingSet, 3},
     {"_flowWorkspace_combineGatingSet", (DL_FUNC) &_flowWorkspace_combineGatingSet, 2},


### PR DESCRIPTION
via the new load_format flag. 
Options are `c("default","in-memory","on-disk").
If default, the stored format is used.
If in-memory data is loaded as MemCytoFrame
if on-disk, data are loaded as Tile or H5 CytoFrame.

TODO: Write unit tests.
related to https://github.com/FredHutch/cytolib/commit/71abd4f6f5cba4013c268e92ffa5e6af2a79d71a