### PR TITLE
Allow more efficient manipulation of individual keywords in cytoframes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flowWorkspace
 Type: Package
 Title: Infrastructure for representing and interacting with gated and ungated cytometry data sets.
-Version: 4.1.11
+Version: 4.1.12
 Date: 2011-06-10
 Author: Greg Finak, Mike Jiang
 Maintainer: Greg Finak <gfinak@fhcrc.org>,Mike Jiang <wjiang2@fhcrc.org>,Jake Wagner <jpwagner@fhcrc.org>
@@ -17,7 +17,7 @@ LazyLoad: yes
 Imports:
     Biobase,
     BiocGenerics,
-    cytolib (>= 2.1.19),
+    cytolib (>= 2.1.20),
     lattice,
     latticeExtra,
     XML,

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -338,12 +338,20 @@ cf_getKeywords <- function(fr) {
     .Call(`_flowWorkspace_cf_getKeywords`, fr)
 }
 
-setKeywords <- function(fr, keys) {
-    invisible(.Call(`_flowWorkspace_setKeywords`, fr, keys))
+cf_setKeywords <- function(fr, keys) {
+    invisible(.Call(`_flowWorkspace_cf_setKeywords`, fr, keys))
 }
 
-setKeywordsSubset <- function(fr, keys) {
-    invisible(.Call(`_flowWorkspace_setKeywordsSubset`, fr, keys))
+cf_setKeywordsSubset <- function(fr, keys, values) {
+    invisible(.Call(`_flowWorkspace_cf_setKeywordsSubset`, fr, keys, values))
+}
+
+cf_renameKeywords <- function(fr, old_keys, new_keys) {
+    invisible(.Call(`_flowWorkspace_cf_renameKeywords`, fr, old_keys, new_keys))
+}
+
+cf_removeKeywords <- function(fr, keys) {
+    invisible(.Call(`_flowWorkspace_cf_removeKeywords`, fr, keys))
 }
 
 getncol <- function(fr) {

--- a/R/cytoframe.R
+++ b/R/cytoframe.R
@@ -630,7 +630,7 @@ setReplaceMethod("keyword",
       if(length(n) == 0)
         stop(kwdError, call.=FALSE)
 	  value <- collapse_desc(value) #flattern and coerce any R object to string
-      setKeywords(object@pointer, value)
+      cf_setKeywords(object@pointer, value)
       return(object)
     })
 
@@ -640,59 +640,63 @@ setReplaceMethod("keyword",
 #' of keywords in \code{\link{cytoframe}} objects.
 #' 
 #' @param cf a \code{cytoframe}
-#' @param keyword the keyword name to insert/delete/replace
-#' @param value the value to associate with the supplied keyword
-#' @param values a named character vector of replacement values, whose names are the keys whose values will be replaced
-#' @param from the old keyword name (for renaming)
-#' @param to the new keyword name (for renamiing)
+#' @param keys the keyword names to insert/delete/replace -- single value or vector
+#' @param values the values to associate with the supplied keywords -- single value or vector of sample length as keys
+#' @param old_keys the old keyword name (for renaming)
+#' @param new_keys the new keyword name (for renamiing)
 #' 
 #' @rdname cytoframe-keywords
 #' @aliases cf_keyword_insert cf_keyword_rename cf_keyword_delete cf_keyword_set
 #' @export
-cf_keyword_insert <- function(cf, keyword, value){
+cf_keyword_insert <- function(cf, keys, values){
   kw <- keyword(cf)
   kn <- names(kw)
-  idx <- match(keyword, kn)
-  if(!is.na(idx))
-    stop("keyword already exists:", keyword)
-  kw[[keyword]] <- value
-  keyword(cf) <- kw
-  
+  idx <- match(keys, kn)
+  dup_idx <- !is.na(idx)
+  if(any(dup_idx))
+    stop("keywords already exist!:", paste(keys[dup_idx], collapse = ", "))
+  cf_setKeywordsSubset(cf@pointer, keys, values)
 }
 
 #' @rdname cytoframe-keywords
 #' @export
-cf_keyword_delete <- function(cf, keyword){
-  kw <- keyword(cf)
-  kn <- names(kw)
-  idx <- match(keyword, kn)
-  na_idx <- is.na(idx)
-  if(any(na_idx))
-    stop("keyword not found:", paste(keyword[na_idx], collapse = ", "))
-  keyword(cf) <- kw[-idx]
- 	
-  
-}
-
-#' @rdname cytoframe-keywords
-#' @export
-cf_keyword_rename <- function(cf, from, to){
-  kw <- keyword(cf)
-  kn <- names(kw)
-  idx <- match(from, kn)
-  if(is.na(idx))
-    stop("keyword not found:", from)
-  names(keyword(cf))[idx] <- to
-}
-
-#' @rdname cytoframe-keywords
-#' @export
-cf_keyword_set <- function(cf, values){
+cf_keyword_delete <- function(cf, keys){
   if(!is(cf, "cytoframe"))
     stop("cf must be a cytoframe object")
-  if(length(names(values)) == 0)
-    stop("values must be a named character vector", call.=FALSE)
-  setKeywordsSubset(cf@pointer, values)
+  if(!is.vector(keys))
+    stop("keys must be a vector")
+  kw <- keyword(cf)
+  kn <- names(kw)
+  idx <- match(keys, kn)
+  na_idx <- is.na(idx)
+  if(any(na_idx))
+    stop("keyword not found:", paste(keys[na_idx], collapse = ", "))
+ 	cf_removeKeywords(cf@pointer, keys);
+}
+
+#' @rdname cytoframe-keywords
+#' @export
+cf_keyword_rename <- function(cf, old_keys, new_keys){
+  if(!is(cf, "cytoframe"))
+    stop("cf must be a cytoframe object")
+  if(!(is.vector(old_keys) && is.vector(new_keys) && length(old_keys) == length(new_keys)))
+    stop("old_keys and new_keys must be vectors of equal length")
+  kw <- keyword(cf) 
+  kn <- names(kw)
+  idx <- match(old_keys, kn)
+  if(any(is.na(idx)))
+    stop("keyword not found:", paste(old_keys[na_idx], collapse = ", "))
+  cf_renameKeywords(cf@pointer, old_keys, new_keys);
+}
+
+#' @rdname cytoframe-keywords
+#' @export
+cf_keyword_set <- function(cf, keys, values){
+  if(!is(cf, "cytoframe"))
+    stop("cf must be a cytoframe object")
+  if(!(is.vector(keys) && is.vector(values) && length(keys) == length(values)))
+    stop("keys and values must be character vectors of equal length")
+  cf_setKeywordsSubset(cf@pointer, keys, values)
 }
 
 #' Methods for conversion between flowCore and flowWorkspace data classes

--- a/man/cytoframe-keywords.Rd
+++ b/man/cytoframe-keywords.Rd
@@ -7,26 +7,24 @@
 \alias{cf_keyword_set}
 \title{\code{cytoframe} keyword access methods}
 \usage{
-cf_keyword_insert(cf, keyword, value)
+cf_keyword_insert(cf, keys, values)
 
-cf_keyword_delete(cf, keyword)
+cf_keyword_delete(cf, keys)
 
-cf_keyword_rename(cf, from, to)
+cf_keyword_rename(cf, old_keys, new_keys)
 
-cf_keyword_set(cf, values)
+cf_keyword_set(cf, keys, values)
 }
 \arguments{
 \item{cf}{a \code{cytoframe}}
 
-\item{keyword}{the keyword name to insert/delete/replace}
+\item{keys}{the keyword names to insert/delete/replace -- single value or vector}
 
-\item{value}{the value to associate with the supplied keyword}
+\item{values}{the values to associate with the supplied keywords -- single value or vector of sample length as keys}
 
-\item{from}{the old keyword name (for renaming)}
+\item{old_keys}{the old keyword name (for renaming)}
 
-\item{to}{the new keyword name (for renamiing)}
-
-\item{values}{a named character vector of replacement values, whose names are the keys whose values will be replaced}
+\item{new_keys}{the new keyword name (for renamiing)}
 }
 \description{
 These methods allow for direct insertion, deletion, or renaming

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -890,25 +890,49 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// setKeywords
-void setKeywords(Rcpp::XPtr<CytoFrameView> fr, List keys);
-RcppExport SEXP _flowWorkspace_setKeywords(SEXP frSEXP, SEXP keysSEXP) {
+// cf_setKeywords
+void cf_setKeywords(Rcpp::XPtr<CytoFrameView> fr, List keys);
+RcppExport SEXP _flowWorkspace_cf_setKeywords(SEXP frSEXP, SEXP keysSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::XPtr<CytoFrameView> >::type fr(frSEXP);
     Rcpp::traits::input_parameter< List >::type keys(keysSEXP);
-    setKeywords(fr, keys);
+    cf_setKeywords(fr, keys);
     return R_NilValue;
 END_RCPP
 }
-// setKeywordsSubset
-void setKeywordsSubset(Rcpp::XPtr<CytoFrameView> fr, StringVector keys);
-RcppExport SEXP _flowWorkspace_setKeywordsSubset(SEXP frSEXP, SEXP keysSEXP) {
+// cf_setKeywordsSubset
+void cf_setKeywordsSubset(Rcpp::XPtr<CytoFrameView> fr, StringVector keys, StringVector values);
+RcppExport SEXP _flowWorkspace_cf_setKeywordsSubset(SEXP frSEXP, SEXP keysSEXP, SEXP valuesSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::XPtr<CytoFrameView> >::type fr(frSEXP);
     Rcpp::traits::input_parameter< StringVector >::type keys(keysSEXP);
-    setKeywordsSubset(fr, keys);
+    Rcpp::traits::input_parameter< StringVector >::type values(valuesSEXP);
+    cf_setKeywordsSubset(fr, keys, values);
+    return R_NilValue;
+END_RCPP
+}
+// cf_renameKeywords
+void cf_renameKeywords(Rcpp::XPtr<CytoFrameView> fr, StringVector old_keys, StringVector new_keys);
+RcppExport SEXP _flowWorkspace_cf_renameKeywords(SEXP frSEXP, SEXP old_keysSEXP, SEXP new_keysSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<CytoFrameView> >::type fr(frSEXP);
+    Rcpp::traits::input_parameter< StringVector >::type old_keys(old_keysSEXP);
+    Rcpp::traits::input_parameter< StringVector >::type new_keys(new_keysSEXP);
+    cf_renameKeywords(fr, old_keys, new_keys);
+    return R_NilValue;
+END_RCPP
+}
+// cf_removeKeywords
+void cf_removeKeywords(Rcpp::XPtr<CytoFrameView> fr, StringVector keys);
+RcppExport SEXP _flowWorkspace_cf_removeKeywords(SEXP frSEXP, SEXP keysSEXP) {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<CytoFrameView> >::type fr(frSEXP);
+    Rcpp::traits::input_parameter< StringVector >::type keys(keysSEXP);
+    cf_removeKeywords(fr, keys);
     return R_NilValue;
 END_RCPP
 }
@@ -1266,8 +1290,10 @@ static const R_CallMethodDef CallEntries[] = {
     {"_flowWorkspace_cf_transform_data", (DL_FUNC) &_flowWorkspace_cf_transform_data, 2},
     {"_flowWorkspace_cf_getKeyword", (DL_FUNC) &_flowWorkspace_cf_getKeyword, 2},
     {"_flowWorkspace_cf_getKeywords", (DL_FUNC) &_flowWorkspace_cf_getKeywords, 1},
-    {"_flowWorkspace_setKeywords", (DL_FUNC) &_flowWorkspace_setKeywords, 2},
-    {"_flowWorkspace_setKeywordsSubset", (DL_FUNC) &_flowWorkspace_setKeywordsSubset, 2},
+    {"_flowWorkspace_cf_setKeywords", (DL_FUNC) &_flowWorkspace_cf_setKeywords, 2},
+    {"_flowWorkspace_cf_setKeywordsSubset", (DL_FUNC) &_flowWorkspace_cf_setKeywordsSubset, 3},
+    {"_flowWorkspace_cf_renameKeywords", (DL_FUNC) &_flowWorkspace_cf_renameKeywords, 3},
+    {"_flowWorkspace_cf_removeKeywords", (DL_FUNC) &_flowWorkspace_cf_removeKeywords, 2},
     {"_flowWorkspace_getncol", (DL_FUNC) &_flowWorkspace_getncol, 1},
     {"_flowWorkspace_getnrow", (DL_FUNC) &_flowWorkspace_getnrow, 1},
     {"_flowWorkspace_setpdata", (DL_FUNC) &_flowWorkspace_setpdata, 2},

--- a/src/cytoframeAPI.cpp
+++ b/src/cytoframeAPI.cpp
@@ -243,7 +243,7 @@ KW_PAIR cf_getKeywords(Rcpp::XPtr<CytoFrameView> fr){
 }
 
 // [[Rcpp::export]] 
-void setKeywords(Rcpp::XPtr<CytoFrameView> fr, List keys){
+void cf_setKeywords(Rcpp::XPtr<CytoFrameView> fr, List keys){
     vector<string> names = keys.names();
     KEY_WORDS kws;
     for(int i = 0; i < keys.size(); i++) 
@@ -252,10 +252,21 @@ void setKeywords(Rcpp::XPtr<CytoFrameView> fr, List keys){
 }
 
 // [[Rcpp::export]]
-void setKeywordsSubset(Rcpp::XPtr<CytoFrameView> fr, StringVector keys){
-    vector<string> names = keys.attr("names");
+void cf_setKeywordsSubset(Rcpp::XPtr<CytoFrameView> fr, StringVector keys, StringVector values){
     for(int i = 0; i < keys.size(); i++)
-      fr->set_keyword(names[i], as<string>(keys[i]));
+      fr->set_keyword(as<string>(keys[i]), as<string>(values[i]));
+}
+
+// [[Rcpp::export]]
+void cf_renameKeywords(Rcpp::XPtr<CytoFrameView> fr, StringVector old_keys, StringVector new_keys){
+  for(int i = 0; i < old_keys.size(); i++)
+    fr->rename_keyword(as<string>(old_keys[i]), as<string>(new_keys[i]));
+}
+
+// [[Rcpp::export]]
+void cf_removeKeywords(Rcpp::XPtr<CytoFrameView> fr, StringVector keys){
+  for(int i = 0; i < keys.size(); i++)
+    fr->remove_keyword(as<string>(keys[i]));
 }
 
 // [[Rcpp::export]] 

--- a/tests/testthat/cytoframe-suite.R
+++ b/tests/testthat/cytoframe-suite.R
@@ -382,9 +382,34 @@ test_that("keyword setters", {
   cf_keyword_rename(cf1, "k1", "k2")
   expect_error(cf_keyword_rename(cf1, "k1", "k2"), "not found")
   expect_equal(keyword(cf1)[["k2"]], "2")
+  #set (subset)
+  cf_keyword_set(cf1, "k2", 5)
+  expect_equal(keyword(cf1)[["k2"]], "5")
   #delete
   cf_keyword_delete(cf1, "k2")
   expect_error(cf_keyword_delete(cf1, "k2"), "not found")
+  
+  # Testing vectorized operations
+  cf1 <- realize_view(cf)
+  #add new
+  cf_keyword_insert(cf1, c("k1", "k2", "k3"), c("red", 5, 1.23))
+  # If any is already present, the call should fail
+  expect_error(cf_keyword_insert(cf1, c("k1", "k2"), c("blue", 6)), "exist")
+  #rename
+  cf_keyword_rename(cf1, c("k1", "k2"), c("key1", "key2"))
+  expect_error(cf_keyword_rename(cf1, c("k1", "k2"), c("key1", "key2")), "not found")
+  expected <- list("red", "5")
+  names(expected) <- c("key1", "key2")
+  expect_equal(keyword(cf1)[c("key1", "key2")], expected)
+  #set (subset) -- overwrite two and add one
+  cf_keyword_set(cf1, c("key1", "key2", "key4"), c("green", 7, "newval"))
+  expected <- list("green", "7", "1.23", "newval")
+  names(expected) <- c("key1", "key2", "k3", "key4")
+  expect_equal(keyword(cf1)[c("key1", "key2", "k3", "key4")], expected)
+  #delete
+  cf_keyword_delete(cf1, c("key2", "key4"))
+  # If any are not longer present, the call should fail
+  expect_error(cf_keyword_delete(cf1, c("key2", "k3")), "not found")
 })
 # test_that("range", {
 # cf <- flowFrame_to_cytoframe(GvHD[[1]])


### PR DESCRIPTION
The [`cf_keyword_` methods](https://github.com/RGLab/flowWorkspace/blob/79b4bf0f057c35611b21e1a56f8613af80c69e71/R/cytoframe.R#L637-L696) currently rely on altering individual keywords at the R level in `cytoframe` objects before re-assigning the full set of keywords. For example, `cf_keyword_delete`:

1) Pulls the keywords to an [R-level list](https://github.com/RGLab/flowWorkspace/blob/79b4bf0f057c35611b21e1a56f8613af80c69e71/R/cytoframe.R#L666l)
2) Removes the appropriate entry and reassigns the [full list](https://github.com/RGLab/flowWorkspace/blob/79b4bf0f057c35611b21e1a56f8613af80c69e71/R/cytoframe.R#L672)

The replacement is done by constructing an entirely new `cytolib::KW_PAIR` object and then replacing the full set of keywords [using `cytolib::CytoFrame::set_keywords`](https://github.com/RGLab/flowWorkspace/blob/79b4bf0f057c35611b21e1a56f8613af80c69e71/src/cytoframeAPI.cpp#L246-L252)

These changes rely on additional direct keyword manipulation methods added by https://github.com/RGLab/cytolib/pull/43 and aim to:

1) Improve efficiency by manipulating individual key-value pairs at the `cytolib` level to avoid a full construction and replacement via [`cytolib::CytoFrame::set_keywords`](https://github.com/RGLab/cytolib/blob/41aab2021fe45b32bca1f5d2707edb2d8930c7dd/inst/include/cytolib/CytoFrame.hpp#L227-L229).
2) Allow the `cf_keyword_` methods to take vectors of keys and values to both make for more convenient/flexible functions and push the loop iterations down to the `cytolib` level.

A simple example testing/benchmarking script and its output follow:

```
library(flowCore)
library(flowWorkspace)
library(microbenchmark)

fcs_path <- system.file("extdata", "CytoTrol_CytoTrol_1.fcs", package = "flowWorkspaceData")
cf <- load_cytoframe_from_fcs(fcs_path, backend = "mem")
cf_test <- realize_view(cf)

# Setup for benchmarking and quick demonstration
test_keywords <- c("EXPERIMENT NAME", "WINDOW EXTENSION")
test_values <- c("C3_Bcell", "11.00")
keyword(cf_test)[test_keywords]

test_full <- keyword(cf)
test_full[test_keywords] <- test_values

cf_keyword_set(cf_test, test_keywords, test_values)
keyword(cf_test)[test_keywords]


## The function logic before the changes
cf_keyword_insert_old <- function(cf, keyword, value){
  kw <- keyword(cf)
  kn <- names(kw)
  idx <- match(keyword, kn)
  if(!is.na(idx))
    stop("keyword already exists:", keyword)
  kw[[keyword]] <- value
  keyword(cf) <- kw
}

cf_keyword_delete_old <- function(cf, keyword){
  kw <- keyword(cf)
  kn <- names(kw)
  idx <- match(keyword, kn)
  na_idx <- is.na(idx)
  if(any(na_idx))
    stop("keyword not found:", paste(keyword[na_idx], collapse = ", "))
  keyword(cf) <- kw[-idx]
}

cf_keyword_rename_old <- function(cf, from, to){
  kw <- keyword(cf)
  kn <- names(kw)
  idx <- match(from, kn)
  if(is.na(idx))
    stop("keyword not found:", from)
  names(keyword(cf))[idx] <- to
}

print("Benchmarking...")
for(backend_type in c("mem", "h5", "tile")){
  print("**********\n")
  cf <- load_cytoframe_from_fcs(fcs_path, backend = backend_type)
  cf_test <- realize_view(cf)
  print(paste0("Verifying backend: ", flowWorkspace:::cf_backend_type(cf_test)))
  print("cf_keyword_insert")
  print(microbenchmark(old = {cf_keyword_insert_old(cf_test, "new_key", "new_val")},
                 new = cf_keyword_insert(cf_test, "new_key", "new_val"),
                 times = 10,
                 setup = cf_test <- realize_view(cf)))
  
  print("cf_keyword_delete")
  print(microbenchmark(old = cf_keyword_delete_old(cf_test, "EXPERIMENT NAME"),
                 new = cf_keyword_delete(cf_test, "EXPERIMENT NAME"),
                 times = 10,
                 setup = cf_test <- realize_view(cf)))
  
  print("cf_keyword_rename")
  print(microbenchmark(old = cf_keyword_rename_old(cf_test, "EXPERIMENT NAME", "EXPT NM"),
                 new = cf_keyword_rename(cf_test, "EXPERIMENT NAME", "EXPT NM"),
                 times = 10,
                 setup = cf_test <- realize_view(cf)))
  
  print("cf_keyword_set") #no old comparator other than keyword<-)
  print(microbenchmark(full_replacement = keyword(cf_test)[test_keywords]<-test_values,
                 partial_replacement = cf_keyword_set(cf_test, test_keywords, test_values),
                 times = 10,
                 setup = cf_test <- realize_view(cf)))
  cat("**********\n")
}
```

The benchmarking output:

```
**********
[1] "Verifying backend: mem"
[1] "cf_keyword_insert"
Unit: microseconds
 expr      min       lq      mean   median       uq      max neval cld
  old 1800.873 1907.335 2925.3342 2090.085 2754.430 6635.035    10   b
  new  250.306  271.746  313.4167  300.784  335.581  459.588    10  a 
[1] "cf_keyword_delete"
Unit: microseconds
 expr      min       lq      mean   median       uq      max neval cld
  old 1824.475 1917.642 2617.2808 1966.323 2068.181 8435.488    10   b
  new  247.142  251.111  282.2386  267.337  306.658  366.803    10  a 
[1] "cf_keyword_rename"
Unit: microseconds
 expr      min       lq      mean    median       uq      max neval cld
  old 1945.592 2008.290 2513.2999 2020.5335 2175.649 6480.525    10   b
  new  244.523  247.253  296.1272  259.7325  297.966  504.266    10  a 
[1] "cf_keyword_set"
Unit: microseconds
                expr      min       lq      mean    median       uq      max neval cld
    full_replacement 1795.993 1868.284 1965.0380 1914.8370 1980.634 2493.492    10   b
 partial_replacement   23.446   24.628   32.2512   25.4405   41.665   55.462    10  a 
**********
**********
[1] "Verifying backend: h5"
[1] "cf_keyword_insert"
Unit: microseconds
 expr      min       lq      mean   median       uq      max neval cld
  old 1763.239 1872.059 1995.0506 2031.793 2070.011 2193.694    10   b
  new  254.134  264.404  333.4856  339.918  360.156  436.972    10  a 
[1] "cf_keyword_delete"
Unit: microseconds
 expr      min       lq      mean   median       uq      max neval cld
  old 1838.566 1930.412 1976.6836 1947.431 2004.548 2153.734    10   b
  new  273.895  286.799  317.0669  303.564  330.590  385.658    10  a 
[1] "cf_keyword_rename"
Unit: microseconds
 expr      min       lq      mean   median       uq      max neval cld
  old 1967.031 2029.698 2144.7114 2154.432 2181.240 2345.294    10   b
  new  268.429  287.707  320.3019  315.955  354.322  379.741    10  a 
[1] "cf_keyword_set"
Unit: microseconds
                expr      min       lq     mean   median       uq      max neval cld
    full_replacement 1751.977 1918.547 1993.517 1993.418 2115.405 2166.282    10   b
 partial_replacement   28.907   30.727   39.638   33.239   47.835   62.673    10  a 
**********
**********
[1] "Verifying backend: tile"
[1] "cf_keyword_insert"
Unit: microseconds
 expr      min       lq     mean    median       uq      max neval cld
  old 1589.161 1697.365 1744.378 1720.8110 1819.443 1916.139    10   b
  new  251.994  252.300  279.778  259.4335  290.371  357.807    10  a 
[1] "cf_keyword_delete"
Unit: microseconds
 expr      min       lq      mean    median       uq      max neval cld
  old 1543.048 1618.277 1709.1417 1725.5665 1815.820 1856.563    10   b
  new  266.460  269.846  279.1537  275.9585  285.833  297.836    10  a 
[1] "cf_keyword_rename"
Unit: microseconds
 expr      min       lq      mean   median       uq      max neval cld
  old 1709.765 1803.822 1892.0482 1851.283 2001.363 2195.599    10   b
  new  262.759  273.404  307.8543  293.800  338.686  395.405    10  a 
[1] "cf_keyword_set"
Unit: microseconds
                expr      min       lq      mean   median       uq      max neval cld
    full_replacement 1534.826 1629.764 1817.7551 1860.925 2005.054 2069.633    10   b
 partial_replacement   29.006   29.419   34.9146   30.355   32.422   74.375    10  a 
**********
```