### PR TITLE
cache hash for pop vs id since it is expensive to compute for large tree

### DIFF
--- a/tests/testthat/GatingSet-testSuite.R
+++ b/tests/testthat/GatingSet-testSuite.R
@@ -336,12 +336,12 @@ test_that("gs_pop_get_count_fast",{
       
       expect_equal(as.data.table(thisRes[,1:2]), expectRes[,-1, with = F], tol = 2e-3)
       
-      #use auto path
-      stats_wide <- gs_pop_get_count_fast(gs, format = "wide", path = "auto")
+      #use auto path #EDIT auto is no longer supported for long fmt
+      stats_wide <- gs_pop_get_count_fast(gs, format = "wide", path = "full")
       stats_wide <- stats_wide[-match("root", rownames(stats_wide)), ] #remove root
       stats_wide <- as.data.frame(stats_wide)
       #get long format
-      stats_long <- gs_pop_get_count_fast(gs, format = "long", path = "auto")
+      stats_long <- gs_pop_get_count_fast(gs, format = "long", path = "full")
       
       #convert it to wide to do the comparsion
       stats_long[, value := Count]


### PR DESCRIPTION
This is before the patch

```r
library(flowWorkspace)
gs = load_gs("~/Downloads/xxx_gating_set")
> length(gs_get_pop_paths(gs))
[1] 11026
> microbenchmark::microbenchmark(gs_pop_get_count_fast(gs[1:16])
+                                , times = 1)
Unit: seconds
                            expr      min       lq     mean   median       uq      max neval
 gs_pop_get_count_fast(gs[1:16]) 63.65044 63.65044 63.65044 63.65044 63.65044 63.65044     1
```

After apply https://github.com/RGLab/cytolib/pull/48 and this PR

```r
Unit: seconds
                            expr       min        lq      mean    median        uq       max neval
 gs_pop_get_count_fast(gs[1:16]) 0.3776194 0.3776194 0.3776194 0.3776194 0.3776194 0.3776194     1
```

again, it passes tests locally.
```r
[ FAIL 0 | WARN 18 | SKIP 21 | PASS 1668 ]
```