### PR TITLE
Update gs_cyto_data<- to support replacement with flowSet objects.

### DIFF
--- a/R/GatingSet_Methods.R
+++ b/R/GatingSet_Methods.R
@@ -528,6 +528,9 @@ setReplaceMethod("flowData",signature(x="GatingSet"),function(x,value){
 #' @rdname gs_cyto_data
 #' @export
 setReplaceMethod("gs_cyto_data",signature(x="GatingSet"),function(x,value){
+      if(class(value) != "cytoset") {
+        value <- flowSet_to_cytoset(value)
+      }
 			set_cytoset(x@pointer, value@pointer)
 			x
 		})


### PR DESCRIPTION
This PR addresses the issue raised #372 where `gs_cyto_data()` replacement method no longer works for `flowSet` objects. 

We don't want to remove support for `flowSet` objects just yet as many users/developers still create `GatingSet` objects by passing in `flowSet` objects -  so we need to provide replacement method that supports `flowSet` objects too.

To fix this, we perform a class check on `value` and if it isn't a `cytoset` we convert it using `flowSet_to_cytoset()` before updating it in the GatingSet.

Successfully tested locally with `flowSet`, `ncdfFlowSet` and `cytoset` replacement values.