### PR TITLE
Use case insensitive argument matching to avoid conflicts with internal APIs

### DIFF
--- a/R/GatingSet_Methods.R
+++ b/R/GatingSet_Methods.R
@@ -810,8 +810,8 @@ gs_pop_get_count_fast <- function(x, statistic = c("count", "freq"), xml = FALSE
 		 return(.gslist_get_pop_stats(x, format, statistic, xml, subpopulations, path, ...))
       # Based on the choice of statistic, the population statistics are returned for
       # each Gating Hierarchy within the GatingSet.
-      statistic <- match.arg(statistic)
-      format <- match.arg(format)
+      statistic <- match.arg(tolower(statistic), c("count", "freq"))
+      format <- match.arg(format, c("long", "wide"))
       path <- match.arg(path, c("full", "auto"))
 
       if(format == "long"){

--- a/R/getStats.R
+++ b/R/getStats.R
@@ -87,7 +87,7 @@ gh_pop_get_stats <- function(x, nodes = NULL, type = "count", xml = FALSE, inver
   res <- sapply(nodes, function(node){
     if(is.character(type))
     {
-      type <- match.arg(type, c("count", "percent"))
+      type <- match.arg(tolower(type), c("count", "percent"))
 	  stats<-.getPopStat(x,y = node)
 	  source <- ifelse(xml, "xml", "openCyto")
 	


### PR DESCRIPTION
@mikejiang, I noticed some inconsistencies between our internal and external APIs with respect to the expected inputs for `type` in `gh_pop_get_stats()` and `statistic` in `gs_pop_get_count_fast()`. Internal APIs require leading capitalisation (e.g. "Count") whilst external APIs require lower case (e.g. "count").

To avoid any conflicts, I have converted the inputs for external APIs to lower case before calling `match.arg()`. This will ensure that any internal code using leading capitalisation for these arguments will still work with external APIs as well.

We should probably have a discussion to settle on a consistent convention for all APIs and then I can help to tidy up the code base to resolve any conflicts. In some cases, such as in `gh_pop_get_stats_tfilter()` leading capitalisation is required for the `type` argument for both internal and external APIs.

I have run all tests in test suite locally and they pass as expected.
